### PR TITLE
Switched to container optimized hardcoded links. 

### DIFF
--- a/build-blackarch.sh
+++ b/build-blackarch.sh
@@ -68,7 +68,7 @@ sudo rm -rf /tmp/arch-bootstrap
 echo "" >> /bedrock/strata/blackarch/etc/pacman.conf
 
 # Container arch doesn't have bin in the root dir
-sudo strat -r ln -s /usr/bin /bin
+sudo strat blackarch -r ln -s /usr/bin /bin
 
 chmod +x /tmp/strap.sh
 strat -r blackarch /tmp/strap.sh

--- a/build-blackarch.sh
+++ b/build-blackarch.sh
@@ -57,7 +57,7 @@ fi
 
 # Set up a base Arch stratum
 ##brl fetch arch -n blackarch
-curl -sOJL "https://gitlab.archlinux.org/api/v4/projects/10185/packages/generic/rootfs/20241006.0.268140/base-20241006.0.268140.tar.zst"
+curl -OJL "https://gitlab.archlinux.org/api/v4/projects/10185/packages/generic/rootfs/20241006.0.268140/base-20241006.0.268140.tar.zst"
 mkdir /tmp/arch-bootstrap
 tar -C /tmp/arch-bootstrap --extract --file base-20241006.0.268140.tar.zst
 sudo brl import blackarch /tmp/arch-bootstrap
@@ -66,6 +66,10 @@ sudo rm -rf /tmp/arch-bootstrap
 # Install BlackArch in the BlackArch stratum
 # Echoing an empty line into pacman.conf prevents a bug where the BlackArch repos are treated as if they belong to another repository.
 echo "" >> /bedrock/strata/blackarch/etc/pacman.conf
+
+# Container arch doesn't have bin in the root dir
+sudo strat -r ln -s /usr/bin /bin
+
 chmod +x /tmp/strap.sh
 strat -r blackarch /tmp/strap.sh
 

--- a/build-blackarch.sh
+++ b/build-blackarch.sh
@@ -60,7 +60,7 @@ fi
 curl -sOJL "https://gitlab.archlinux.org/api/v4/projects/10185/packages/generic/rootfs/20241006.0.268140/base-20241006.0.268140.tar.zst"
 mkdir /tmp/arch-bootstrap
 tar -C /tmp/arch-bootstrap --extract --file base-20241006.0.268140.tar.zst
-sudo brl import blackarch /tmp/arch-bootstrap
+sudo brl import arch /tmp/arch-bootstrap
 sudo rm -rf /tmp/arch-bootstrap
 
 # Install BlackArch in the BlackArch stratum

--- a/build-blackarch.sh
+++ b/build-blackarch.sh
@@ -56,7 +56,12 @@ else
 fi
 
 # Set up a base Arch stratum
-brl fetch arch -n blackarch
+##brl fetch arch -n blackarch
+curl -sOJL "https://gitlab.archlinux.org/api/v4/projects/10185/packages/generic/rootfs/20241006.0.268140/base-20241006.0.268140.tar.zst"
+mkdir /tmp/arch-bootstrap
+tar -C /tmp/arch-bootstrap --extract --file base-20241006.0.268140.tar.zst
+sudo brl import blackarch /tmp/arch-bootstrap
+sudo rm -rf /tmp/arch-bootstrap
 
 # Install BlackArch in the BlackArch stratum
 # Echoing an empty line into pacman.conf prevents a bug where the BlackArch repos are treated as if they belong to another repository.

--- a/build-blackarch.sh
+++ b/build-blackarch.sh
@@ -60,7 +60,7 @@ fi
 curl -sOJL "https://gitlab.archlinux.org/api/v4/projects/10185/packages/generic/rootfs/20241006.0.268140/base-20241006.0.268140.tar.zst"
 mkdir /tmp/arch-bootstrap
 tar -C /tmp/arch-bootstrap --extract --file base-20241006.0.268140.tar.zst
-sudo brl import arch /tmp/arch-bootstrap
+sudo brl import blackarch /tmp/arch-bootstrap
 sudo rm -rf /tmp/arch-bootstrap
 
 # Install BlackArch in the BlackArch stratum

--- a/build-kali.sh
+++ b/build-kali.sh
@@ -59,7 +59,7 @@ if [ -f "$file" ]; then
     echo "Kali Linux ISO file already exists. Skipping download."
 else
     echo "Kali Linux ISO file does not exist. Downloading latest Kali Linux image."
-    wget https://cdimage.kali.org/kali-2020.4/kali-linux-2020.4-live-amd64.iso -O /tmp/kali.iso
+    wget https://cdimage.kali.org/kali-2024.3/kali-linux-2024.3-live-amd64.iso -O /tmp/kali.iso
 fi
 
 # Mount the Kali Image

--- a/build-kali.sh
+++ b/build-kali.sh
@@ -31,6 +31,13 @@ else
     exit 1
 fi
 
+if command -v fuseiso >/dev/null 2>&1 ; then
+    echo "fuseiso found."
+else
+    echo "Missing dependency: fuseiso was not found. Please install."
+    exit 1
+fi
+
 if command -v unsquashfs >/dev/null 2>&1 ; then
     echo "unsquashfs found."
 else
@@ -64,10 +71,17 @@ fi
 
 # Mount the Kali Image
 mkdir /tmp/mnt
-mount /tmp/kali.iso /tmp/mnt
+#mount /tmp/kali.iso /tmp/mnt
+fuseiso /tmp/kali.iso /tmp/mnt
 
 # Build the stratum
-unsquashfs -d /bedrock/strata/kali /tmp/mnt/live/filesystem.squashfs
+mkdir /tmp/kalidir
+unsquashfs -d /tmp/kalidir /tmp/mnt/live/filesystem.squashfs
+
+sudo brl import kali /tmp/kalidir
+
+rmdir /tmp/mnt
+rmdir /tmp/kalidir
 
 # Implement a dpkg Statoverride fix 
 #  Statoverride (From https://bedrocklinux.org/1.0beta2/troubleshooting.html)

--- a/build_amzn.sh
+++ b/build_amzn.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# BlackArch Stratum Builder for Bedrock Linux
+
+# Creating a BlackArch Stratum on Bedrock
+
+# Print header
+echo "===================================="
+echo "=== AMAZON LINUX STRATUM BUILDER ==="
+echo "===================================="
+
+# Check dependencies and permissions
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root."
+   exit 1
+fi
+
+if command -v brl >/dev/null 2>&1 ; then
+    echo "Bedrock is installed."
+else
+    echo "Missing dependency: Bedrock Linux was not found. Please install."
+    exit 1
+fi
+
+if command -v wget >/dev/null 2>&1 ; then
+    echo "wget found."
+else
+    echo "Missing dependency: wget was not found. Please install."
+    exit 1
+fi
+
+# Make sure the BlackArch stratum doesn't already exist
+if [ -d "/bedrock/strata/amzn" ]; then
+    echo "amzn stratum already exists."
+    exit 1
+else
+    echo "No existing amzn stratum detected."
+fi
+
+echo "pulling amazon linux container image"
+wget https://cdn.amazonlinux.com/os-images/2.0.20241001.0/container/amzn2-container-raw-2.0.20241001.0-x86_64.tar.xz
+sudo brl import amzn amzn2-container-raw-2.0.20241001.0-x86_64.tar.xz
+rm -f amzn2-container-raw-2.0.20241001.0-x86_64.tar.xz
+
+# Show that the stratum is there
+echo "Done."
+echo "Currently enabled strata:"
+brl list

--- a/build_amzn.sh
+++ b/build_amzn.sh
@@ -41,6 +41,11 @@ wget https://cdn.amazonlinux.com/os-images/2.0.20241001.0/container/amzn2-contai
 sudo brl import amzn amzn2-container-raw-2.0.20241001.0-x86_64.tar.xz
 rm -f amzn2-container-raw-2.0.20241001.0-x86_64.tar.xz
 
+#fix the mount tables
+echo "fixing the amazon mtab file"
+sudo rm -f /bedrock/strata/amzn/etc/mtab
+sudo brl repair amzn
+
 # Show that the stratum is there
 echo "Done."
 echo "Currently enabled strata:"


### PR DESCRIPTION
This repository may have to be updated from time to time with new links as the methods used don't automatically check for the latest versions of these OS.
Contributing because I found myself using bedrock as a way to easily spin up pentesting environments with all the tools in one place. 
I added amazon linux as a test case to make sure I understood the operation of the scripts. (also because its one of the default choices for an EC2 server.)
